### PR TITLE
Disable persistent volume for openldap

### DIFF
--- a/charts/oes/Chart.yaml
+++ b/charts/oes/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: oes
-version: 3.6.4
+version: 3.6.5
 appVersion: 3.6.2
 description: OES is a non-forked version of OSS spinnaker
 icon: https://www.opsmx.com/images/logo.png

--- a/charts/oes/values.yaml
+++ b/charts/oes/values.yaml
@@ -573,7 +573,7 @@ openldap:
   configPassword: opsmxconfig123
   omitClusterIP: true
   persistence:
-    enabled: true
+    enabled: false
   env:
     LDAP_REMOVE_CONFIG_AFTER_SETUP: "false"
 


### PR DESCRIPTION
- Enabling persistence by default is eating up too many PVCs on clusters