### PR TITLE
Controller Service Type Updated

### DIFF
--- a/charts/oes/templates/forwarder/oes-forwarder-svc-ipc.yaml
+++ b/charts/oes/templates/forwarder/oes-forwarder-svc-ipc.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   selector:
     app: opsmx-controller-controller1
-  type: ClusterIP
+  type: {{ .Values.forwarder.agent.serviceType }}
   ports:
   - name: agent-grpc
     port: 9001


### PR DESCRIPTION
Got Service Type Settings for forwarder from values.yaml

## Values of Forwarder/Controller
##
forwarder:
  enabled: false
  agent:
    image: quay.io/opsmxpublic/forwarder-agent:v20210118T161303
    serviceType: LoadBalancer