### PR TITLE
s3 pipeline promotion fix

### DIFF
--- a/charts/oes/charts/spinnaker/templates/configmap/halyard-init-script.yaml
+++ b/charts/oes/charts/spinnaker/templates/configmap/halyard-init-script.yaml
@@ -64,6 +64,7 @@ data:
     sed -i  s/GIT_USER/${GIT_USER}/g /tmp/spinnaker/.hal/default/profiles/spinnakerconfig.yml
     sed -i  s/GIT_TOKEN/${GIT_TOKEN}/g /tmp/spinnaker/.hal/default/profiles/spinnakerconfig.yml
     sed -i  's|DYNAMIC_ACCOUNTS_REPO|'"${DYNAMIC_ACCOUNTS_REPO}"'|' /tmp/spinnaker/.hal/default/profiles/spinnakerconfig.yml
+    sed -i  s%DYN_ACCNT_CONFG_PATH%{{ .Values.gitopsHalyard.repo.dynAccntConfigPath }}%g /tmp/spinnaker/.hal/default/profiles/spinnakerconfig.yml
     sed -i  s/RELEASE_NAME/{{ .Release.Name }}/g /tmp/spinnaker/.hal/default/service-settings/redis.yml
     if [ -f /tmp/spinnaker/.hal/default/profiles/fiat-local.yml ]; then
     sed -i  s/RELEASE_NAME/{{ .Release.Name }}/g /tmp/spinnaker/.hal/default/profiles/fiat-local.yml

--- a/charts/oes/templates/pipeline-promotion/pipe-promot-config-cm.yaml
+++ b/charts/oes/templates/pipeline-promotion/pipe-promot-config-cm.yaml
@@ -8,8 +8,8 @@ data:
     repo_name={{ .Values.spinnaker.gitopsHalyard.pipelinePromotion.repository }}
     root_folder={{ .Values.spinnaker.gitopsHalyard.pipelinePromotion.rootFolder }}
     #S3 Specific
-    AWS_ACCESS_KEY_ID={{ .Values.spinnaker.gitopsHalyard.pipelinePromotion.AWS_ACCESS_KEY_ID }}
-    AWS_SECRET_ACCESS_KEY={{ .Values.spinnaker.gitopsHalyard.pipelinePromotion.AWS_SECRET_ACCESS_KEY }}
+    export AWS_ACCESS_KEY_ID={{ .Values.spinnaker.gitopsHalyard.pipelinePromotion.AWS_ACCESS_KEY_ID }}
+    export AWS_SECRET_ACCESS_KEY={{ .Values.spinnaker.gitopsHalyard.pipelinePromotion.AWS_SECRET_ACCESS_KEY }}
 
     #git mandatory patameters
     git_url={{ .Values.spinnaker.gitopsHalyard.pipelinePromotion.baseUrl }}

--- a/charts/oes/templates/pipeline-promotion/pipe-promot-scripts-cm.yaml
+++ b/charts/oes/templates/pipeline-promotion/pipe-promot-scripts-cm.yaml
@@ -254,7 +254,7 @@ data:
       # get the pipeline data from spinnaker and store in root_folder
       get_pipelines_data
       #upload spinnaker pipelines data and upload to s3 folder
-      aws s3 cp $tempdir$s3_folder s3://$bucket_name/$s3_folder --recursive
+      aws s3 cp $tempdir/$bucket_name/$s3_folder s3://$bucket_name/$s3_folder --recursive
       if [ "$?" != 0 ]; then
               echo "[ERROR]: Failed to upload to bucket" $bucket_name
       else

--- a/charts/oes/values.yaml
+++ b/charts/oes/values.yaml
@@ -1035,6 +1035,7 @@ spinnaker:
       repository: standard-gitops-repo # repo name for GitOps Halyard (Sample Reference: https://github.com/OpsMx/sample-gitops-repo.git).
       dynamicAccRepository: standard-gitops-repo # Please provide the repo name of the GitOps Dynamic Accounts Directory.Can be same as Hal repo. 
       halConfigPath: / # Any other value is currently not supported
+      dynAccntConfigPath: dynaccount/ #relative path from repository root folder
       username: <git/stash_username>  # Username to authenticate with git/stash repo
       token: <git/stash_token>  # Token corresponding to above username
       ## Configure below fields only if repo type is s3


### PR DESCRIPTION
we see without export command aws credentials are not recognized as env variables. so added export in pipe-promot-config-cm.yaml