### PR TITLE
Updated images, changed plugin repo-path in gate.yml

### DIFF
--- a/charts/oes/config/oes-gate/gate.yml
+++ b/charts/oes/config/oes-gate/gate.yml
@@ -203,7 +203,8 @@ spinnaker:
           version: 1.0.1
     repositories:
         opsmx-repo:
-          url: https://raw.githubusercontent.com/OpsMx/spinnakerPluginRepository/v3.9.0/plugins.json
+          url: url: file:///opt/spinnaker/plugins/plugins.json
+          #url: https://raw.githubusercontent.com/OpsMx/spinnakerPluginRepository/v3.9.0/plugins.json
 {{- end }}
 
 logging:

--- a/charts/oes/values.yaml
+++ b/charts/oes/values.yaml
@@ -298,7 +298,7 @@ autopilot:
   image:
     registry: quay.io/opsmxpublic
     repository: ubi8-oes-autopilot
-    tag: v3.9.5
+    tag: v3.9.5.2
     pullPolicy: IfNotPresent
 
   annotations:
@@ -347,7 +347,7 @@ dashboard:
   image:
     registry: quay.io/opsmxpublic
     repository: ubi8-oes-dashboard
-    tag: v3.9.5
+    tag: v3.9.5.2
     pullPolicy: IfNotPresent
 
   annotations:
@@ -401,7 +401,7 @@ gate:
   image:
     registry: quay.io/opsmxpublic
     repository: ubi8-gate
-    tag: v3.9.5
+    tag: v3.9.5.2
     pullPolicy: IfNotPresent
 
   serviceAnnotations: {}
@@ -490,7 +490,7 @@ platform:
   image:
     registry: quay.io/opsmxpublic
     repository: ubi8-oes-platform
-    tag: v3.9.5
+    tag: v3.9.5.2
     pullPolicy: IfNotPresent
 
   annotations:
@@ -548,7 +548,7 @@ sapor:
   image:
     registry: quay.io/opsmxpublic
     repository: ubi8-oes-sapor
-    tag: v3.9.5
+    tag: v3.9.5.2
     pullPolicy: IfNotPresent
 
   annotations:
@@ -632,7 +632,7 @@ ui:
   image:
     registry: quay.io/opsmxpublic
     repository: ubi8-oes-ui
-    tag: v3.9.5.0
+    tag: v3.9.5.2
     pullPolicy: IfNotPresent
   serviceAnnotations: {}
 
@@ -651,7 +651,7 @@ visibility:
   image:
     registry: quay.io/opsmxpublic
     repository: ubi8-oes-visibility
-    tag: v3.9.5
+    tag: v3.9.5.2
     pullPolicy: IfNotPresent
 
   annotations:


### PR DESCRIPTION
Updated the images to 3.9.5.2 that contain the log4j security fix. Also, changed the gate.yml so that plugins are not downloaded on the internet. The corrosponding change to orca-local.yml has been done in standard-gitops-repo