### PR TITLE
removed git clone for sample app creation

### DIFF
--- a/charts/oes/charts/spinnaker/templates/configmap/spin-pipeline-import.yaml
+++ b/charts/oes/charts/spinnaker/templates/configmap/spin-pipeline-import.yaml
@@ -34,9 +34,8 @@ data:
     {{- end }}
     then
         echo \"Spinnaker and OES is Installed and ready\"
-        mkdir -p /tmp/config/git/
-        git -c {{ .Values.gitopsHalyard.repo.configArgs }} clone https://github.com/OpsMx/sample-pipelines.git /tmp/config/git/
         cd /tmp/config/git
+        cp -r /tmp/sample/. /tmp/config/git
         cp -p /tmp/config/spin/config .
         sed 's/$/ --config config/' create-app.sh >create-app1.sh
         bash -xe create-app1.sh

--- a/charts/oes/charts/spinnaker/templates/deployments/create-sample-job.yaml
+++ b/charts/oes/charts/spinnaker/templates/deployments/create-sample-job.yaml
@@ -26,7 +26,7 @@ spec:
         - bash
         - /tmp/config/spin-pipeline-import.sh
         name: sample-pipeline-install
-        image: {{ .Values.global.customImages.registry }}/spin-sample-pipeline:1.0
+        image: {{ .Values.global.customImages.registry }}/spin-pipeline-samples:v1
         volumeMounts:         
         - name: spin-pipeline-config
           mountPath: /tmp/config/git


### PR DESCRIPTION
Removed git clone for sample app creation by creating a new image (https://quay.io/repository/opsmxpublic/spin-pipeline-samples:v1) with sample pipelines repo already clone inside.