### PR TITLE
added text to explain organization in GitOps section

### DIFF
--- a/charts/oes/values.yaml
+++ b/charts/oes/values.yaml
@@ -690,7 +690,7 @@ spinnaker:
       enabled: true
       type: git  # git, s3, stash
       gitConfig: "git config --global http.sslVerify false"
-      organization: project_name  # Also called "project" in some repos
+      organization: OpsMx, <PersonalRepoName>, or project_name  # Also called "project" in some repos
       repository: repo_name  # bucket name in case of S3
       rootFolder: pipeline/
       ##### ONLY In case of S3


### PR DESCRIPTION
Matching the usage of the term 'organization' in the help text in the GitOps section 'Pipeline Promotion' to the the main GitOps section, 'halyard config repo' to create consistency and disambiguate. 