### PR TITLE
OES Release v3.10.2

### DIFF
--- a/charts/oes/Chart.yaml
+++ b/charts/oes/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: oes
-version: 3.10.5
-appVersion: 3.10.1
-description: ISD 3.10.1 supporting externalRedis and Node Selection rules.
+version: 3.10.6
+appVersion: 3.10.2
+description: Config changes in ISD components for 3.10.2 and minor Helm fixes
 icon: https://raw.githubusercontent.com/OpsMx/enterprise-spinnaker/master/img/opsmx.png
 maintainers:
 - email: srinivas@opsmx.io

--- a/charts/oes/charts/spinnaker/templates/configmap/halyard-config.yaml
+++ b/charts/oes/charts/spinnaker/templates/configmap/halyard-config.yaml
@@ -175,6 +175,14 @@ data:
     $HAL_COMMAND config security authn ldap disable
     {{- end }}
 
+    # Enable Authorization 
+    {{- if .Values.global.commonGate.spinnakerRBAC }}
+    $HAL_COMMAND config security authz enable
+    {{- else }}
+    $HAL_COMMAND config security authz disable
+    {{- end }}
+
+
     # Use Deck to route to Gate
     {{- if not .Values.gitopsHalyard.enabled }}
     # Configure override urls in halyard config

--- a/charts/oes/charts/spinnaker/templates/configmap/halyard-init-script.yaml
+++ b/charts/oes/charts/spinnaker/templates/configmap/halyard-init-script.yaml
@@ -50,26 +50,47 @@ data:
     {{- if or (eq .Values.gitopsHalyard.repo.type "git") (eq .Values.gitopsHalyard.repo.type "stash") }}
     #!/bin/bash -x
     rm -rf /tmp/spinnaker/.hal
+    {{- if not .Values.gitopsHalyard.repo.sshkeysecret }}
+    GIT_USER=`echo $GIT_USER | sed 's/ *$//g'`
+    GIT_TOKEN=`echo $GIT_TOKEN | sed 's/ *$//g'`
     git -c {{ .Values.gitopsHalyard.repo.configArgs }} clone $GIT_CLONE_PARAM -b {{ .Values.gitopsHalyard.repo.halConfigBranch}} /tmp/spinnaker/test
+    {{- end }}
     cp -pr /tmp/spinnaker/test/{{ .Values.gitopsHalyard.repo.halConfigPath }} /tmp/spinnaker/.hal
     if [ -d "/tmp/spinnaker/test/pipeline-promotion/" ]
     then
        cp -pr /tmp/spinnaker/test/pipeline-promotion /tmp/spinnaker/pipeline-promotion
     fi
     rm -rf /tmp/spinnaker/test
-    GIT_USER=`echo $GIT_USER | sed 's/ *$//g'`
-    GIT_TOKEN=`echo $GIT_TOKEN | sed 's/ *$//g'`
     DYNAMIC_ACCOUNTS_REPO=`echo $DYNAMIC_ACCOUNTS_REPO | sed 's/ *$//g'`
     sed -i  s/SPINNAKER_NAMESPACE/${SPINNAKER_NAMESPACE}/ /tmp/spinnaker/.hal/config
     sed -i  s/RELEASE_NAME/{{ .Release.Name }}/g /tmp/spinnaker/.hal/config
     {{- if .Values.gitopsHalyard.environment }}
     sed -i  s/ENVIRONMENT/{{ .Values.gitopsHalyard.environment }}/g /tmp/spinnaker/.hal/config
     {{- end }}
+    {{- if .Values.gitopsHalyard.repo.sshkeysecret }}
+    mv /tmp/spinnaker/.hal/default/profiles/spinnakerconfig.yml.ssh /tmp/spinnaker/.hal/default/profiles/spinnakerconfig.yml
+    cat /etc/git-secret/ssh | sed 's/^/                       /' > /tmp/spinnaker/_temp
+    cd /tmp/spinnaker/
+    sed -i.bak '/|/r _temp' /tmp/spinnaker/.hal/default/profiles/spinnakerconfig.yml
+    DYNAMIC_ACCOUNTS_REPO=git@{{ .Values.gitopsHalyard.repo.baseUrlHostName }}:{{ .Values.gitopsHalyard.repo.organization }}/{{ .Values.gitopsHalyard.repo.dynamicAccRepository }}.git
+    {{- else }}
     sed -i  s/GIT_USER/${GIT_USER}/g /tmp/spinnaker/.hal/default/profiles/spinnakerconfig.yml
     sed -i  s/GIT_TOKEN/${GIT_TOKEN}/g /tmp/spinnaker/.hal/default/profiles/spinnakerconfig.yml
+    {{- end }}
     sed -i  's|DYNAMIC_ACCOUNTS_REPO|'"${DYNAMIC_ACCOUNTS_REPO}"'|' /tmp/spinnaker/.hal/default/profiles/spinnakerconfig.yml
     sed -i  s%DYN_ACCNT_CONFG_PATH%{{ .Values.gitopsHalyard.repo.dynAccntConfigPath }}%g /tmp/spinnaker/.hal/default/profiles/spinnakerconfig.yml
     sed -i  s/RELEASE_NAME/{{ .Release.Name }}/g /tmp/spinnaker/.hal/default/service-settings/redis.yml
+    {{- if not .Values.global.ldap.enabled }}
+    yq e '.deploymentConfigurations.[].security.authn.ldap.enabled = "false"' config > config1
+    mv config1 config
+    {{- end }}
+    {{- if .Values.global.commonGate.spinnakerRBAC }}
+    yq e '.deploymentConfigurations.[].security.authz.enabled = "true"' config > config1
+    mv config1 config
+    {{- else }}
+    yq e '.deploymentConfigurations.[].security.authz.enabled = "false"' config > config1
+    mv config1 config
+    {{- end }}
     if [ -f /tmp/spinnaker/.hal/default/profiles/fiat-local.yml ]; then
     sed -i  s/RELEASE_NAME/{{ .Release.Name }}/g /tmp/spinnaker/.hal/default/profiles/fiat-local.yml
     fi

--- a/charts/oes/charts/spinnaker/templates/configmap/halyard-overrideurl.yaml
+++ b/charts/oes/charts/spinnaker/templates/configmap/halyard-overrideurl.yaml
@@ -132,6 +132,12 @@ data:
       spin-gate-overrideurl-gitops)
         ## Configured ingress host url as override url
           echo "Substituting gate url"
+          {{- if .Values.global.ssl.enabled }}
+          sed -i 's,PROTOCOL,https,g' /tmp/spinnaker/.hal/config
+          {{- else }}
+          sed -i 's,PROTOCOL,http,g' /tmp/spinnaker/.hal/config
+          {{- end }}
+         
           {{- if .Values.global.commonGate.enabled }}
           sed -i 's,OVERRIDE_API_URL,{{ tpl .Values.global.oesGate.host . }},g' /tmp/spinnaker/.hal/config
           {{- else }}

--- a/charts/oes/charts/spinnaker/templates/statefulsets/halyard.yaml
+++ b/charts/oes/charts/spinnaker/templates/statefulsets/halyard.yaml
@@ -44,7 +44,7 @@ spec:
       initContainers:
       - name: "create-halyard-local"
       {{- if .Values.gitopsHalyard.enabled }}
-        image: {{ .Values.global.customImages.registry }}/awsgit:v2
+        image: {{ .Values.global.customImages.registry }}/awsgit:v2-openssh
       {{- else }}
         image: {{ .Values.halyard.image.repository }}:{{ .Values.halyard.image.tag }}
       {{- end }}

--- a/charts/oes/config/oes-autopilot/autopilot.properties
+++ b/charts/oes/config/oes-autopilot/autopilot.properties
@@ -37,4 +37,6 @@ ds.async.flow=false
 #storage.region= {{ .Values.global.minio.region }}
 ds.seperate.service=false
 
-
+# Logging Level
+logging.level.com.opsmx.analytics=ERROR
+datasource.secretManagement.source = {{ .Values.secretStore }}

--- a/charts/oes/config/oes-datascience/app-config.yml
+++ b/charts/oes/config/oes-datascience/app-config.yml
@@ -21,7 +21,7 @@ POSTGRES:
       DB: autopilotqueue
 
 RABBITMQ:
-      USERNAME: 'guest'
-      PASSWORD: 'guest'
+      USERNAME: 'rabbitmq'
+      PASSWORD: 'Networks123'
       HOST: rabbitmq-service
       PORT: 5672

--- a/charts/oes/config/oes-gate/gate.yml
+++ b/charts/oes/config/oes-gate/gate.yml
@@ -192,6 +192,13 @@ server:
     internalProxies: .*
     protocolHeader: X-Forwarded-Proto
     remoteIpHeader: X-Forwarded-For
+gate:
+  installation:
+    {{- if .Values.global.commonGate.enabled }}
+    mode: common    #Allowed values are --> oes,common
+    {{- else }}
+    mode: oes
+    {{- end }} 
 {{- if .Values.global.commonGate.enabled }}
 spinnaker:
   extensibility:

--- a/charts/oes/config/oes-visibility/visibility-local.yml
+++ b/charts/oes/config/oes-visibility/visibility-local.yml
@@ -57,3 +57,8 @@ autopilot:
 platform:
   service:
     url: http://oes-platform:8095
+
+datasource:
+  secretManagement:
+    source: {{ .Values.secretStore }}
+

--- a/charts/oes/templates/hooks/cleanup.yaml
+++ b/charts/oes/templates/hooks/cleanup.yaml
@@ -20,9 +20,9 @@ spec:
         image: {{ .Values.spinnaker.halyard.image.repository }}:{{ .Values.spinnaker.halyard.image.tag }}
         command: ["/bin/bash","-c"]
 {{- if .Values.global.certManager.installed }}
-        args: ["kubectl delete issuer letsencrypt-{{ .Release.Namespace }}-spin; kubectl delete ingress oes-gate-ingress oes-ui-ingress {{ template "spinnaker.fullname" . }}-deck; kubectl delete secret ca-secret deck-authtls demo-authtls jwt-secret oes-cacerts oes-control-secret oes-gate-authtls oes-ui-authtls"]
+        args: ["kubectl delete issuer --ignore-not-found letsencrypt-{{ .Release.Namespace }}-spin; kubectl delete ingress --ignore-not-found oes-gate-ingress oes-ui-ingress {{ template "spinnaker.fullname" . }}-deck; kubectl delete secret --ignore-not-found ca-secret deck-authtls demo-authtls jwt-secret oes-cacerts oes-control-secret oes-gate-authtls oes-ui-authtls"]
 {{- else }}
-        args: ["kubectl delete ingress oes-gate-ingress oes-ui-ingress {{ template "spinnaker.fullname" . }}-deck; kubectl delete secret ca-secret jwt-secret oes-cacerts oes-control-secret"]
+        args: ["kubectl delete ingress --ignore-not-found oes-gate-ingress oes-ui-ingress {{ template "spinnaker.fullname" . }}-deck; kubectl delete secret --ignore-not-found ca-secret jwt-secret oes-cacerts oes-control-secret"]
 {{- end }}
 {{- end }}
       {{- if .Values.global.nodeSelector }}

--- a/charts/oes/templates/secrets/bootstrap-secret.yaml
+++ b/charts/oes/templates/secrets/bootstrap-secret.yaml
@@ -24,6 +24,9 @@ stringData:
     jasypt:
       encryptor:
         password: {{ .Values.sapor.config.encrypt.key }}
+    datasource:
+      secretManagement:
+        source: {{ .Values.secretStore }}
 kind: Secret
 metadata:
   name: bootstrap

--- a/charts/oes/templates/spinnaker-extra/ingress.yml
+++ b/charts/oes/templates/spinnaker-extra/ingress.yml
@@ -31,7 +31,7 @@ spec:
   tls:
   - hosts:
     - {{ .Values.spinnaker.ingress.host }}
-    secretName: ui-{{ .Release.Name }}-tls
+    secretName: spinnaker-deck-ingress
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -78,6 +78,6 @@ spec:
   tls:
   - hosts:
     - {{ .Values.spinnaker.ingressGate.host }}
-    secretName: api-{{ .Release.Name }}-tls
+    secretName: spinnaker-gate-ingress
 {{- end }}
 {{- end }}

--- a/charts/oes/values.yaml
+++ b/charts/oes/values.yaml
@@ -104,7 +104,7 @@ global:
       annotations:
         kubernetes.io/ingress.class: nginx
       tls:
-        secretName: oes-ui-authtls
+        secretName: oes-ui-ingress
 
   ## OES-Gate url configuration
   oesGate:
@@ -117,7 +117,7 @@ global:
       annotations:
         kubernetes.io/ingress.class: nginx
       tls:
-        secretName: oes-gate-authtls
+        secretName: oes-ui-ingress
 
   ###############################################################################
   # A trial LDAP is installed by default, with users: admin, user1,2,3 with user1password, user2pa...
@@ -1026,12 +1026,12 @@ spinnaker:
   ## Here basic ldap auth is used by default; everything under spinCli will be pasted in ~/.spin/config
   spinCli:
     gate:
-      endpoint: http://oes-gate:8084 # URL that needs to be used to talk to spinnaker gate and create sample pipelines
+      endpoint: http://spin-gate:8084 # URL that needs to be used to talk to spinnaker gate and create sample pipelines
     auth:
       enabled: true
       basic:
-        username: admin          # Use credentials corresponding to spinCli.gate.endpoint
-        password: opsmxadmin123  # Use credentials corresponding to spinCli.gate.endpoint
+        username: admin          # Use credentials corresponding to saporgate.config.username
+        password: saporadmin     # Use credentials corresponding to saporgate.config.password
 
 ###############################################################################################
 ###############################################################################################

--- a/charts/oes/values.yaml
+++ b/charts/oes/values.yaml
@@ -117,7 +117,7 @@ global:
       annotations:
         kubernetes.io/ingress.class: nginx
       tls:
-        secretName: oes-ui-ingress
+        secretName: oes-gate-ingress
 
   ###############################################################################
   # A trial LDAP is installed by default, with users: admin, user1,2,3 with user1password, user2pa...

--- a/charts/oes/values.yaml
+++ b/charts/oes/values.yaml
@@ -410,9 +410,9 @@ gate:
     #####################################################
     # keytool -genkey -v -keystore oessaml.jks -alias saml -keyalg RSA -keysize 2048 -validity 10000
     # oessaml.jks and oesmetadata.xml are mounted as secrets, create them as follows
-    # kubectl create secret generic oesmetadataxml --from-file=oesmetadata.xml
-    # kubectl create secret generic oessamljks --from-file=oessaml.jks
-    # kubectl create secret generic samljks-password --from-literal password=changeit 
+    # kubectl create secret generic oesmetadataxml --from-file=oesmetadata.xml -n <namespace>
+    # kubectl create secret generic oessamljks --from-file=oessaml.jks -n <namespace>
+    # kubectl create secret generic samljks-password --from-literal password=changeit -n <namespace>
     saml:
       enabled: false
       userSource: gate  # Groups will be obtained from SAML

--- a/charts/oes/values.yaml
+++ b/charts/oes/values.yaml
@@ -237,7 +237,7 @@ autopilot:
   ## Image specific details
   image:
     repository: ubi8-oes-autopilot
-    tag: v3.10.1
+    tag: v3.10.2
     pullPolicy: IfNotPresent
 
   annotations:
@@ -269,7 +269,7 @@ audit:
   ##
   image:
     repository: ubi8-oes-audit-service
-    tag: v3.10.1
+    tag: v3.10.2
     pullPolicy: IfNotPresent
 
   serviceAnnotations: {}
@@ -290,7 +290,7 @@ auditClient:
   ##
   image:
     repository: ubi8-oes-audit-client
-    tag: v3.10.1
+    tag: v3.10.2
     pullPolicy: IfNotPresent
 
   serviceAnnotations: {}
@@ -311,7 +311,7 @@ datascience:
   ##
   image:
     repository: ubi8-oes-datascience
-    tag: v3.10.1
+    tag: v3.10.2
     pullPolicy: IfNotPresent
 
   serviceAnnotations: {}
@@ -329,7 +329,7 @@ dashboard:
   ## Image specific details
   image:
     repository: ubi8-oes-dashboard
-    tag: v3.10.1
+    tag: v3.10.2
     pullPolicy: IfNotPresent
 
   annotations:
@@ -379,7 +379,7 @@ gate:
   ## Image specific details
   image:
     repository: ubi8-gate
-    tag: v3.10.1
+    tag: v3.10.2
     pullPolicy: IfNotPresent
 
   serviceAnnotations: {}
@@ -453,7 +453,7 @@ platform:
   ## Image specific details
   image:
     repository: ubi8-oes-platform
-    tag: v3.10.1
+    tag: v3.10.2
     pullPolicy: IfNotPresent
 
   annotations:
@@ -494,7 +494,7 @@ rabbitmq:
   url: rabbitmq-service
   port: 5672
   image:
-    registry: docker.io/rabbitmq
+    registry: quay.io/opsmxpublic/rabbitmq
     repository: 3-management
   serviceAnnotations: {}
 
@@ -504,7 +504,7 @@ sapor:
   ## Image specific details
   image:
     repository: ubi8-oes-sapor
-    tag: v3.10.1
+    tag: v3.10.2
     pullPolicy: IfNotPresent
 
   annotations:
@@ -590,7 +590,7 @@ ui:
   ## Image specific details
   image:
     repository: ubi8-oes-ui
-    tag: v3.10.1
+    tag: v3.10.2
     pullPolicy: IfNotPresent
   serviceAnnotations: {}
 
@@ -604,7 +604,7 @@ visibility:
   ## Image specific details
   image:
     repository: ubi8-oes-visibility
-    tag: v3.10.1
+    tag: v3.10.2
     pullPolicy: IfNotPresent
 
   annotations:


### PR DESCRIPTION
1. Datascience (Added the username/password for the rabbitmq).
2. Gate (Added mode of installation).
3. Added source for secretmanagement(Visibility,Autopilot,bootstrap)
4. Protocol is substituted in the override urls of hal config
5. Spin-CLI uses the sapor-gate to create sample apps
6. Handled the spinnakerRBAC in the gitops Style
7. Added the ignore not found in the clean up jobs
8. Updated the create-halyard-local init container image( awsgit:v2-openssh included yq - Dockerfile can be found in the custom-stages awsgit folder)
9. changed the names of the Ingress objects to match the TLS secret