### PR TITLE
removed prometheus alerts for gate, audit-service, datascience pods

### DIFF
--- a/charts/oes/charts/prometheus/config/spin_alerting_rules.yml
+++ b/charts/oes/charts/prometheus/config/spin_alerting_rules.yml
@@ -255,13 +255,6 @@ groups:
     expr: up{component="auditclient"}==0
     labels:
       severity: critical
-  - alert: oes-audit-service-scrape-target-is-down
-    annotations:
-      description: The scrape target endpoint of component {{$labels.component}} in namespace {{$labels.kubernetes_namespace}} is down
-      summary: oes-audit-service scrape target is down
-    expr: up{component="auditservice"} == 0
-    labels:
-      severity: critical
   - alert: oes-autopilot-scrape-target-is-down
     annotations:
       description: The scrape target endpoint of component {{$labels.component}} in namespace {{$labels.kubernetes_namespace}} is down
@@ -276,20 +269,6 @@ groups:
     expr: up{component="dashboard"}==0
     labels:
       severity: critical		  
-  - alert: oes-datascience-scrape-target-is-down
-    annotations:
-      description: The scrape target endpoint of component {{$labels.component}} in namespace {{$labels.kubernetes_namespace}} is down
-      summary: oes-datascience scrape target is down
-    expr: up{component="datascience"} == 0
-    labels:
-      severity: critical		  
-  - alert: oes-gate-scrape-target-is-down
-    annotations:
-      description: The scrape target endpoint of component {{$labels.component}} in namespace {{$labels.kubernetes_namespace}} is down
-      summary: oes-gate scrape target is down
-    expr: up{component="gate"}==0
-    labels:
-      severity: critical
   - alert: oes-platform-scrape-target-is-down
     annotations:
       description: The scrape target endpoint of component {{$labels.component}} in namespace {{$labels.kubernetes_namespace}} is down

--- a/charts/oes/config/oes-visibility/visibility-local.yml
+++ b/charts/oes/config/oes-visibility/visibility-local.yml
@@ -16,9 +16,27 @@ spring:
           models: 
             parameters:
               AbstractSerializableParameter: ERROR
+
+management:
+  endpoints:
+    web:
+      base-path: /mgmt
+      exposure:
+        include: health,info,metrics,prometheus
+  endpoint:
+    health:
+      show-details: always
+      show-components: always
+  health:
+    elasticsearch:
+      enabled: false
+    ldap:
+      enabled: false
+
 ui:
   approval:
     url: {{ .Values.global.oesUI.protocol }}://{{ .Values.global.oesUI.host }}/ui/application/visibility/{applicationId}/{serviceId}/{approvalGateId}  
+
 gate:
   url: http://oes-gate:8084
 

--- a/charts/oes/values.yaml
+++ b/charts/oes/values.yaml
@@ -296,7 +296,7 @@ audit:
     moniker.spinnaker.io/application: isd
     prometheus_io_path: /mgmt/prometheus
     prometheus_io_port: "8097"
-    prometheus.io/scrape: "true"
+    prometheus.io/scrape: "false"
   resources: {}
   config: {}
 
@@ -340,7 +340,7 @@ datascience:
     moniker.spinnaker.io/application: isd
     prometheus_io_path: /mgmt/prometheus
     prometheus_io_port: "5005"
-    prometheus.io/scrape: "true"
+    prometheus.io/scrape: "false"
   resources: {}
   config: {}
 
@@ -412,7 +412,7 @@ gate:
     moniker.spinnaker.io/application: isd
     prometheus_io_path: /mgmt/prometheus
     prometheus_io_port: "8084"
-    prometheus.io/scrape: "true"
+    prometheus.io/scrape: "false"
   resources: {}
   #  requests:
   #    memory: 500Mi


### PR DESCRIPTION
removed scrape target down alert for gate, audit-service and datascience pod
modified annotations prometheus.io/scrape: false for gate, audit-service and datascience pod
added prometheus endpoint inside visibility-local.yml